### PR TITLE
Load asset from NDK in example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ build/
 .externalNativeBuild
 /android/*/gradlew*
 /android/*/gradle/wrapper/
-/android/*/app/src/main/assets/

--- a/android/fgbl/app/CMakeLists.txt
+++ b/android/fgbl/app/CMakeLists.txt
@@ -19,3 +19,4 @@ add_library(native-lib SHARED src/main/cpp/native-lib.cpp )
 find_library(log-lib log )
 
 target_link_libraries(native-lib LibFgBase ${log-lib} )
+target_link_libraries(native-lib android)

--- a/android/fgbl/app/src/main/assets/hello.txt
+++ b/android/fgbl/app/src/main/assets/hello.txt
@@ -1,0 +1,1 @@
+Hello from asset manager

--- a/android/fgbl/app/src/main/cpp/native-lib.cpp
+++ b/android/fgbl/app/src/main/cpp/native-lib.cpp
@@ -1,22 +1,33 @@
+#include <android/asset_manager_jni.h>
 #include <jni.h>
 #include <string>
 #include <FgCommand.hpp>
+
+#define BUFSIZE 30
 
 void fgGeometryTest(const FgArgs &);
 
 extern "C" JNIEXPORT jstring
 
 JNICALL
-Java_com_facegen_fgbl_MainActivity_stringFromJNI(JNIEnv *env,jobject /* this */) {
+Java_com_facegen_fgbl_MainActivity_stringFromJNI(JNIEnv *env, jobject /* this */, jobject _assetManager) {
 
     std::string         hello;
+    char                buf[BUFSIZE];
+
+    AAssetManager *assetManager = AAssetManager_fromJava(env, _assetManager);
+    AAsset *asset = AAssetManager_open(assetManager, "hello.txt", AASSET_MODE_BUFFER);
+    buf[AAsset_read(asset, buf, BUFSIZE)] = 0;
+    AAsset_close(asset);
+
+    hello = buf;
     try {
         // We run this test because it doesn't create any temp files, which isn't yet set up to work with Android:
         fgGeometryTest(FgArgs());
     }
     catch (...) {
-        hello = "Fgbl test failed.";
+        hello += ". Fgbl test failed.";
     }
-    hello = "Fgbl test passed.";
+    hello += ". Fgbl test passed.";
     return env->NewStringUTF(hello.c_str());
 }

--- a/android/fgbl/app/src/main/java/com/facegen/fgbl/MainActivity.kt
+++ b/android/fgbl/app/src/main/java/com/facegen/fgbl/MainActivity.kt
@@ -3,6 +3,7 @@ package com.facegen.fgbl
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
 import kotlinx.android.synthetic.main.activity_main.*
+import android.content.res.AssetManager
 
 class MainActivity : AppCompatActivity() {
 
@@ -11,14 +12,14 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
 
         // Example of a call to a native method
-        sample_text.text = stringFromJNI()
+        sample_text.text = stringFromJNI(getAssets())
     }
 
     /**
      * A native method that is implemented by the 'native-lib' native library,
      * which is packaged with this application.
      */
-    external fun stringFromJNI(): String
+    external fun stringFromJNI(assetManager: AssetManager): String
 
     companion object {
 


### PR DESCRIPTION
Fixes https://github.com/SingularInversions/FaceGenBaseLibrary/issues/5.

@ab-cpp I couldn't use an istream object since the NDK asset manager API doesn't support it.